### PR TITLE
- DV360 terms of use page

### DIFF
--- a/dv360/terms.html
+++ b/dv360/terms.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<html lang="en-us">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>ZEFR, INC. Dv360 Extension Terms Of Use</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- Place favicon.ico in the root directory -->
+        <link rel="stylesheet" href="../normalize.css">
+        <link rel="stylesheet" href="../style.css">
+        <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
+        <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600|Open+Sans+Condensed:300,700' rel='stylesheet' type='text/css'>
+        <link rel="manifest" href="../manifest.json">
+    </head>
+    <body>
+        <header>
+            <div class="container">
+                <img src="../zefr-white.svg" alt="ZEFR Logo">
+            </div>
+        </header>
+        <main>
+            <article class="container">
+                <h1 class="text-center text-uppercase">
+                    ZEFR, INC. <br />
+                    Dv360 Extension Terms Of Use <br />
+                    <span class="text-capitalize">Last updated July __, 2019</span>
+                </h1>
+                <p>
+                    These Terms of Use set forth the terms and conditions that apply to access and use of the web-based services of ZEFR, Inc., a Delaware corporation (&quot;<em>ZEFR</em>&quot;), as further described herein, by the customer named on the Order Form submitted to ZEFR (&quot;<em>Subscriber</em>&quot;). These Terms of Use, together with any Order Form (each an &quot;<em>Order Form</em>&quot;) submitted by Subscriber and accepted by ZEFR after the date of Subscriber’s agreement to these Terms of Use, together constitute the Agreement (&quot;<em>Agreement</em>&quot;).
+                </p>
+                <p>
+                <strong class="text-uppercase">Whereas</strong>, ZEFR has developed and may in the future develop a proprietary web-browser extension that provides access to ZEFR’s contextual advertising targeting and exclusions data, services and related materials, and Subscriber desires to obtain a right to use such extension and such data, services and materials.
+                </p>
+                <p>
+                    <strong class="text-uppercase">Now therefore</strong>, in consideration of the mutual promises set forth below and subject to the terms and conditions hereof, the parties hereto agree as follows:
+                </p>
+                <ol>
+                    <li>
+                        <h3>License grant. <span class="text-capitalize">
+                            Subject to the terms and conditions of this Agreement, ZEFR hereby grants to Subscriber a limited, non-exclusive, non-sublicensable, non-transferable right and license during the term of this Agreement to use the web-based services identified on the applicable Order Form to access advertising placement data, including but not limited to positive and negative targeting lists, campaign analytics, and other data through ZEFR’s Google Chrome or other internet browser extension, on the website located at displayvideo.google.com or any successor website and includes any mobile versions or applications thereof or related thereto (the &quot;<em>DV360 Platform</em>&quot;), and as further described on such Order Form (the &quot;<em>Services</em>&quot;) and the Documentation, in each case, solely in connection with Subscriber’s internal business operations as set forth herein (the &quot;<em>License</em>&quot;). Subscriber shall not have any rights to the Services except as expressly granted in this Agreement.  ZEFR reserves to itself all rights to the Services not expressly granted pursuant to this Agreement. The term &quot;<em>Documentation</em>&quot; means all ZEFR-provided user documentation, in all forms, relating to the Services (e.g., user manuals, on-line help files and the like).
+                        </span>
+                        </h3>
+                    </li>
+                    <li>
+                        <h3>Use of the services</h3>
+                        <ol>
+                            <li>
+                                <u>Internal Use</u>. The Services are for Subscriber’s use for its own internal business purposes, except with respect to any exceptions or intended applications expressly set forth on the Order Form.  Use of Services is subject to the terms set forth in this Agreement, including the terms of any third-party software described in and incorporated herein pursuant to Section 9.2, and the restrictions set forth in this Section 2 shall survive the termination of this Agreement.
+                            </li>
+                            <li>
+                                <u>Use Restrictions</u>. Except as otherwise explicitly provided in this Agreement or as may be expressly permitted by applicable law, Subscriber shall not, and shall not permit or authorize third parties to: (a) rent, lease, or otherwise permit third parties to use the Services or Documentation; (b) use the Services to provide services to third parties (e.g., as a service bureau); (c) circumvent or disable any security or other technological features or measures of the Services, (d) use the information described in Section 1 hereof in any way not contemplated by this Agreement or export or share such information with any third party nor (e) make copies of such information without ZEFR’s prior written consent. ZEFR shall have no responsibility to Subscriber in any way for any policies, actions, or inactions of third parties, including but not limited to Google or individuals acting on behalf of Subscriber, including any &quot;effective policy&quot;, &quot;applied policy&quot; or other procedures and mechanisms on the DV360 Platform or any other platform.
+                            </li>
+                            <li>
+                                <u>Compliance with Laws</u>. Subscriber shall use the Services and Documentation in compliance with all applicable laws and regulations.
+                            </li>
+                            <li>
+                                <u>Authorized Users Only</u>. This Agreement restricts the use of the Services to those of Subscriber’s employees, specified in writing to ZEFR, who are authorized to purchase media on behalf of Subscriber or to otherwise use the DV360 Platform (each, an &quot;<em>Authorized User</em>&quot;). Authorized Users shall not be permitted to provide or make available their user names or passwords to any other person. An Authorized User account is not permitted to be shared among users. Additional Authorized Users may be added by paying the applicable fees to ZEFR at ZEFR’s then-current rate or as otherwise specified on an Order Form. The term for additional Authorized Users shall be coterminous with (and the pricing prorated for) the expiration of the then-current term of this Agreement.
+                            </li>
+                            <li>
+                                <u>Protection against Unauthorized Use</u>. Subscriber shall use reasonable efforts to prevent any unauthorized use of the Services and Documentation and will immediately notify ZEFR in writing of any unauthorized use that comes to Subscriber’s attention and any suspected unauthorized use. If there is unauthorized use by anyone who obtained access to the Services directly or indirectly through Subscriber, Subscriber shall take all steps reasonably necessary to terminate the unauthorized use. Subscriber shall cooperate and assist with any actions taken by ZEFR to prevent or terminate unauthorized use of the Services or Documentation.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Implementation and support services</h3>
+                        <ol>
+                            <li>
+                                <u>Implementation and Customization Services</u>. No customization or implementation services are included in the Fees (as defined below) unless expressly set forth in an Order Form. Subscriber may contract with ZEFR to perform additional support or other services pursuant to a separate and mutually acceptable services agreement.
+                            </li>
+                            <li>
+                                <u>Technical Support Services</u>. So long as Subscriber is current in payment of the Fees and is not in default of any material terms of this Agreement, ZEFR shall provide tier one support to Subscriber for critical Services failures resulting in complete or substantial shutdown of the Services within one business day of any request, and ZEFR shall respond to all other support requests (as set forth in this Section 3.2, the &quot;<em>Technical Support Services</em>&quot;) as soon as reasonably and commercially practical on an as needed basis at its own cost and expense.  The support in using the Services may occur at the discretion of ZEFR by phone, email, or mail request(s) to ZEFR for help on incidental needs related to use of Services.  Subscriber shall also have web access to online ZEFR training materials, if available, for its internal use only, at no additional charge.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Services</h3>
+                        <ol>
+                            <li>
+                                <u>Consideration</u>. As compensation for the License of the Services set forth in Section 1 above, Subscriber shall pay the Fees as set forth in Section 5.1 and any Order Form. If an Order Form contains a trial or beta period (a &quot;<em>Beta Period</em>&quot;) for a specific period, the Fees for such period shall be waived during the Beta Period. Unless Subscriber terminates such Order Form in writing at least five days prior to the end of such Beta Period, the Order Form shall automatically continue in effect for the remainder of the term set forth on such Order Form, and the Fees for such Order Form (less any Fees accrued during such Beta Period) shall become due and payable in accordance with Section 5.1 of this Agreement.
+                            </li>
+                            <li>
+                                <u>Content</u>.  Subscriber hereby represents and warrants that (a) it owns, controls, or has all necessary rights to and for the use of all content which Subscriber uses in the DV360 Platform (&quot;<em>Content</em>&quot;) and (b) the use of the Content does not infringe, misappropriate, or violate any intellectual property right or any other right of any third party, including, without limitation, copyright, patent, trademark, or moral rights or any other third party right.
+                            </li>
+                            <li>
+                                <u>Retention of Rights</u>. The parties hereby agree that ZEFR shall retain all right, title, and interest worldwide in and to all inventions and intellectual property, and all applicable intellectual property rights related to such inventions, owned by ZEFR as of the date hereof or discovered, conceived or reduced to practice by ZEFR during the term of this Agreement (the &quot;<em>Proprietary Rights</em>&quot;).  This Section 4.3 shall survive termination of this Agreement.
+                            </li>
+                            <li>
+                                <u>Disclaimers</u>. Except as expressly set forth herein, ZEFR makes no representation or warranty of any kind, and specifically disclaims any warranty, that: (i) it will be able to identify any particular level of fan uploaded content on any website, (ii) it will achieve any particular level of financial results, business partnerships, promotions, or affiliations for Subscriber, or (iii) it will be able to optimize or advance search or advertising results with respect to Subscriber or its Content on any website.
+                            </li>
+                            <li>
+                                 <u>License</u>. Subject to the terms and conditions of this Agreement, Subscriber hereby grants to ZEFR, during the Term, (i) such rights and authorizations as are necessary or required by Google LLC and hereinafter, &quot;<em>Google</em>&quot;) for ZEFR to perform or provide access to the Services, (ii) the right and license to use, reproduce, publicly perform and publicly display Subscriber trademarks, service marks and logos (&quot;<em>Marks</em>&quot;), in accordance with usage guidelines for the Marks which may be provided by Subscriber in writing from time to time, for the sole purpose of ZEFR’s performing its obligations and exercising its rights and licenses granted herein or as is required of ZEFR by Google pursuant to its sublicense with ZEFR with respect to the subject matter hereof,  and (iii) all other rights, licenses and authorizations as are necessary or required for ZEFR to grant the License or perform or provide access to the Services and its other obligations under this Agreement, including, without limitation, authorization for ZEFR to create and manage an account with Google on behalf of Subscriber.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Fees and payment</h3>
+                        <ol>
+                            <li>
+                                <u>Fees and Payment Terms</u>. ZEFR’s fees for the Services specified on the Order Form (the &quot;<em>Fees</em>&quot;) are set forth in the applicable Order Forms and will be a percentage, set forth on such Order Form(s), of amounts paid by Subscriber to Google with respect to any spend that utilizes the Services. By clicking [&quot;ACCEPT&quot;] on an Order Form submitted to ZEFR, Subscriber agrees to pay to ZEFR the Fees set forth on such Order Form. Fees are due within 30 days of the date of ZEFR’s invoice, which will be issued by ZEFR monthly to Subscriber’s billing contact set forth on the Order Form, which billing contact may be updated by Subscriber upon 30 days’ written notice to ZEFR. For purposes of clarity, Fees will be based on a percentage of actual spend in the applicable calendar month and not over the course of the entire term of the Agreement. Any amount not paid when due shall be subject to finance charges equal to 1.5% of the unpaid balance per month or the highest rate permitted by applicable usury law, whichever is less, determined and compounded daily from the date due until the date paid. Subscriber shall reimburse any costs or expenses (including, but not limited to, reasonable attorneys’ fees) incurred by ZEFR to collect any amount that is not paid when due pursuant to this Agreement. Amounts due from Subscriber pursuant to this Agreement may not be withheld or offset by Subscriber against amounts due to Subscriber for any reason. All amounts payable pursuant to this Agreement are denominated in United States dollars, and Subscriber shall pay all such amounts in United States dollars.
+                            </li>
+                            <li>
+                                Subscriber shall pay Google directly for any fees charged or required by such parties for media purchased by Subscriber. Subscriber will be the responsible billing entity on all services accounts with such parties, regardless of whether ZEFR created such accounts.
+                            </li>
+                            <li>
+                                During the term of this Agreement and for three years thereafter, Subscriber shall keep current, complete, and accurate records regarding the reproduction, installation, and use of the Services and results of the Services.  Subscriber shall provide such information to ZEFR and certify that it has paid all fees required pursuant to this Agreement within fifteen business days of any written request.  Subscriber shall, after reasonable prior notice from ZEFR, provide ZEFR, and its representatives, reasonable access to Subscriber’s premises, records, and personnel so that ZEFR may audit and confirm that Subscriber is in compliance with this Agreement.  If an audit reveals any reproduction, installation, use, or distribution of the Services that is not in compliance with this Agreement, Subscriber shall promptly comply with this Agreement and make an additional payment as necessary to bring Subscriber into compliance with this Agreement, plus interest at the rate specified in this Section 5.  If the amount of the underpayment is 5% or greater, Subscriber shall promptly reimburse ZEFR for its reasonable costs of conducting such audit.
+                            </li>
+                            <li>
+                                <u>Taxes</u>. Other than net income taxes imposed on ZEFR, Subscriber shall bear all taxes, fees, duties, and other governmental charges (collectively, &quot;<em>taxes</em>&quot;) resulting from this Agreement. Subscriber shall pay any additional amounts as are necessary to ensure that the net amounts received by ZEFR after all such taxes are paid are equal to the amounts that ZEFR would have been entitled to in accordance with this Agreement as if the taxes did not exist. For the avoidance of doubt, if ZEFR has the legal obligation to pay or collect taxes for which Subscriber is responsible under this Section, the appropriate amount shall be invoiced to, and paid by, Subscriber unless Subscriber provides ZEFR with a valid tax exemption certificate authorized by the appropriate taxing authority.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Term and termination</h3>
+                        <ol>
+                            <li>
+                                <u>Term</u>. This Agreement shall commence upon the date hereof and continue for one year (the &quot;<em>Initial Term</em>&quot;) unless this Agreement is terminated earlier in accordance with the terms of this Agreement.  For the avoidance of doubt, the License, and Services shall commence upon the delivery of a login granting Subscriber access to the Services, which shall in no event be later than twenty business days following the Effective Date of the initial Order Form.  This Agreement shall automatically renew for additional one year periods, unless at least 60 days before the end of the then-current term either party provides written notice to the other party of its election not to renew. If there are no Order Forms outstanding, then at such time, this Agreement may be terminated by either party after delivering written notice to the other.
+                            </li>
+                            <li>
+                                <u>Termination for Material Breach</u>. Either party may terminate this Agreement if the other party does not cure its material breach of this Agreement within 30 days of receiving written notice of the material breach from the non-breaching party. Termination in accordance with this Section 6.2 shall take effect when the breaching party receives written notice of termination from the non-breaching party, which notice must not be delivered until the breaching party has failed to cure its material breach during the 30-day cure period. If Subscriber fails to timely pay any Fees, ZEFR may, without limitation to any of its other rights or remedies, suspend the License of the Services, and cease performance of any Technical Support Services until it receives all amounts due.  In addition to the foregoing, ZEFR reserves the right to terminate this Agreement in the event that Google takes any actions which materially restrict ZEFR’s ability to provide the License, or to perform or provide access to the Services set forth herein, including, but not limited to, restricting access to information necessary for the performance of the Services.  In the event of any such termination, ZEFR shall refund any then unused, prepaid fees for the remainder of the then-current term.
+                            </li>
+                            <li>
+                                <u>Effect of Termination</u>. If this Agreement is terminated for any reason, (a) Subscriber shall pay to ZEFR any Fees or other amounts that have accrued prior to the effective date of the termination, (b) any and all liabilities accrued prior to the effective date of the termination shall survive, (c) Subscriber shall provide ZEFR with a written certification signed by an authorized Subscriber representative certifying that all use of the Services and Documentation by Subscriber has been discontinued, (d) ZEFR may charge a separate set-up fee to Subscriber if it wishes to activate Services at a later date, and (e) Sections 2, 6, 7, 8, 9.3, 10, 11, 12 and 13 shall survive termination.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Intellectual property</h3>
+                        <ol>
+                            <li>
+                                <u>Ownership</u>. As between the parties, ZEFR retains all right, title, and interest in and to the Services and Documentation. Subscriber understands and agrees that unless otherwise set forth on an Order Form, ZEFR may use and disclose, in an aggregated format only, any and all data derived or collected from Subscriber’s use of the Services and ZEFR’s performance of the Services for the purpose of generally improving the look and feel of the Services and to otherwise operate, manage, maintain and improve ZEFR’s products and services including for developing and distributing benchmarks and similar reports and databases; provided that such aggregated data is not identified or identifiable as originating with or associated with Subscriber or any individual person associated with the Subscriber.
+                            </li>
+                            <li>
+                                <u>Trademarks</u>. This Agreement does not authorize Subscriber to use ZEFR’s name or any of its trademarks, which include, but are not limited to, the word &quot;ZEFR&quot; and the ZEFR logo.
+                            </li>
+                            <li>
+                                <u>Trade Secrets</u>.  The Services are trade secrets of ZEFR and contain valuable proprietary products and information of ZEFR, embodying substantial creative efforts and confidential information, ideas, and expressions.  Subscriber shall take appropriate action to protect the confidentiality of the Services.  Subscriber shall not modify, translate, disassemble, create Derivative Works based on, reverse-assemble, reverse-compile or otherwise reverse-engineer the Services in whole or in part, or otherwise use, copy, reproduce or distribute any deliverable except as expressly permitted hereunder.  The provisions of this Section shall survive the termination of this Agreement.
+                            </li>
+                            <li>
+                                <u>Feedback</u>.  Subscriber hereby grants to ZEFR a royalty-free, fully paid-up, nonexclusive, perpetual, irrevocable, worldwide, transferable (only to a successor in interest by way of merger, reorganization or sale of all or substantially all assets of the business unit performing the Services or  equity, or operation of law), sublicensable license to use, copy, modify, or distribute, including by incorporating into the Services, any suggestions, enhancement requests, recommendations or other feedback provided by Subscriber or its users relating to the operation of the Services. Included in such license is the right to (i) identify or reference Subscriber as a user of ZEFR’s Services and a right to use Subscriber’s logo in connection therewith, and (ii) perform and make public a case study with respect to Subscriber and its use of the Services and results of the Services.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>CONFIDENTIALITY</h3>
+                        <ol>
+                            <li>
+                                All information that either party receives from the other that is marked &quot;confidential&quot; by the disclosing party (hereinafter the &quot;<em>Disclosing Party</em>&quot;) or that would reasonably be considered confidential by a party experienced in the industry (hereinafter &quot;<em>Confidential Information</em>&quot;) shall be kept confidential, and each party agrees to treat (and take precautions to ensure that its employees treat) the Confidential Information as confidential in accordance with the confidentiality requirements and conditions set forth below; provided, however, that ZEFR may disclose this agreement to a party performing financial or legal due diligence with respect to ZEFR.
+                            </li>
+                            <li>
+                                Each party agrees, during the term hereof and for a period of five years thereafter, to keep confidential all Confidential Information disclosed to it by the other party in accordance herewith, and to protect the confidentiality thereof with at least the same standard of care with which it protects the confidentiality of similar information and data of its own (at all times exercising at least a reasonable standard of care in the protection of Confidential Information); provided, however, that neither party shall have any such obligation with respect to the use or disclosure to third parties of such Confidential Information as can be established to: (a) have been known publicly; (b) have been known generally in the industry on a non-confidential basis before communication by the Disclosing Party to the recipient (hereinafter the &quot;<em>Recipient</em>&quot;); (c) have become known publicly; (d) have been known otherwise by the Recipient before communication by the Disclosing Party; (e) have been received by the Recipient without any obligation of confidentiality from a source (other than the Disclosing Party) lawfully having possession of such information; or (f) have been independently developed by the Recipient without reference to the Confidential Information of the Disclosing Party.
+                            </li>
+                            <li>
+                                Except as prohibited by applicable law or legal process or to the extent part of an examination by a regulatory or self-regulatory body, if the Recipient is requested or required (by deposition, interrogatories, requests for information or documents in legal proceedings, subpoenas, regulatory processes (including those of self-regulatory organizations), or similar process) in connection with any proceeding to disclose or otherwise becomes legally compelled to disclose any Confidential Information, the Recipient shall provide the Disclosing Party with prompt written notice and, if requested by the Disclosing Party after receipt of such notice, the Recipient shall provide Disclosing Party with reasonable assistance (subject to reimbursement by the Disclosing Party of all reasonable and out-of-pocket expenses incurred by the Recipient in providing such assistance) so as to enable the Disclosing Party to seek a protective order or other appropriate remedy or waive compliance with this Agreement.  To the extent this Agreement applies, if such a protective order or other remedy is not obtained or if the Disclosing Party waives compliance with this Agreement, the Recipient may disclose Confidential Information, but only such Confidential Information as it is legally required to disclose in the reasonable opinion of counsel to the Recipient, and shall exercise reasonable efforts to obtain reliable assurance that confidential treatment will be accorded such Confidential Information disclosed.  Subscriber’s obligations under this paragraph will survive the termination of this Agreement or of any License granted under this Agreement for whatever reason.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Warranties and disclaimer</h3>
+                        <ol>
+                            <li>
+                                <u>Mutual Warranties</u>. Each party represents and warrants to the other that: (a) each Order Form, once duly executed and delivered, and this Agreement constitute a valid and binding agreement enforceable against such party in accordance with its terms; (b) no authorization or approval from any third party is required in connection with such party’s execution and delivery of the Order Forms, or performance of this Agreement; and (c) the execution and delivery of the Order Forms, and performance of this Agreement, does not violate the laws of any jurisdiction or the terms or conditions of any other agreement to which it is a party or by which it is otherwise bound.
+                            </li>
+                            <li>
+                                <u>Third Party Software</u>. The Services may contain or require use of third party software that requires notices or additional terms and conditions. Such required third party software notices or additional terms and conditions shall be provided to Subscriber from time to time, including, but not limited to, the Google API terms of service located at: <span class="text-break">https://developers.google.com/terms</span>, and are incorporated by reference into this Agreement. By accepting this Agreement, Subscriber is also accepting the additional terms and conditions, if any, set forth in such terms and conditions. ZEFR makes no warranties and accepts no liability with respect to third party software.
+                            </li>
+                            <li>
+                                <u>Disclaimer</u>. <span class="text-uppercase">Except for the express representations and warranties stated in this section 9, ZEFR makes no additional representation or warranty of any kind whether express, implied (either in fact or by operation of law), or statutory, as to any matter whatsoever. ZEFR expressly disclaims all implied warranties of merchantability, fitness for a particular purpose, quality, accuracy, title, and non-infringement. ZEFR does not warrant against interference with the enjoyment of the services. ZEFR does not warrant that the services are error-free or that operation of the services will be secure or uninterrupted. ZEFR exercises no control over and expressly disclaims any liability arising out of or based upon the results of subscriber’s use of the services.</span>
+                            </li>
+                            <li>
+                                <u>Additional Disclaimer</u>. Except as otherwise expressly provided herein, ZEFR makes no representation or warranty of any kind, and specifically disclaims any warranty, that: (i) it will achieve any particular level of financial results for Subscriber, (ii) that the Services will not be interrupted by any third party service or platforms, or (iii) it will be able to enhance Subscriber’s brand value or image in any identifiable manner.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Intellectual property infringement</h3>
+                        <ol>
+                            <li>
+                                <u>Defense of Infringement Claims</u>. ZEFR shall, at its expense, either defend Subscriber from or settle any claim, proceeding, or suit brought by a third party (&quot;<em>Claim</em>&quot;) against Subscriber alleging that Subscriber’s use of the Services infringes or misappropriates any U.S. patent, copyright, trade secret, trademark, or intellectual property right during the term of this Agreement if: (a) Subscriber gives ZEFR prompt written notice of the Claim; (b) Subscriber grants ZEFR full and complete control over the defense and settlement of the Claim; (c) Subscriber provides assistance in connection with the defense and settlement of the Claim as ZEFR may reasonably request; and (d) Subscriber complies with any settlement or court order made in connection with the Claim (e.g., relating to the future use of any infringing Services). Subscriber shall not defend or settle any Claim without ZEFR’s prior written consent. Subscriber shall have the right to participate in the defense of the Claim at its own expense and with counsel of its own choosing, but ZEFR shall have sole control over the defense and settlement of the Claim.
+                            </li>
+                            <li>
+                                <u>Indemnification of Infringement Claims</u>. ZEFR shall indemnify Subscriber from and pay (a) all damages, costs, and attorneys’ fees finally awarded against Subscriber in any Claim pursuant to Section 10.1; (b) all out-of-pocket costs (including reasonable attorneys’ fees) reasonably incurred by Subscriber in connection with the defense of a Claim pursuant to Section 10.1 (other than attorneys’ fees and costs incurred without ZEFR’s consent after ZEFR has accepted defense of the Claim); and, (c) all amounts that ZEFR agrees to pay to any third party to settle any Claim pursuant to Section 10.1.
+                            </li>
+                            <li>
+                                <u>Exclusions from Obligations</u>. ZEFR shall have no obligation pursuant to this Section 10 for any infringement or misappropriation to the extent that it arises out of or is based upon (a) use of the Services in combination with other products or services if such infringement or misappropriation would not have arisen but for such combination; (b) the Services are provided to comply with designs, requirements, or specifications required by or provided by Subscriber, if the alleged infringement or misappropriation would not have arisen but for the compliance with such designs, requirements, or specifications; (c) use of the Services by Subscriber for purposes not intended or outside the scope of the license granted to Subscriber; (d) Subscriber’s failure to use the Services in accordance with instructions provided by ZEFR, if the infringement or misappropriation would not have occurred but for such failure; or (e) any modification of the Services not made or authorized in writing by ZEFR where such infringement or misappropriation would not have occurred absent such modification.
+                            </li>
+                            <li>
+                                <u>Limited Remedy</u>. This Section 10 states ZEFR’s sole and exclusive liability, and Subscriber’s sole and exclusive remedy, for the actual or alleged infringement or misappropriation of any third party intellectual property right by the Services.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Subscriber indemnification</h3>
+                        <ol>
+                            <li>
+                                <u>Defense</u>. Subscriber shall defend ZEFR from any actual or threatened Claim arising out of or based upon Subscriber’s use of the Services, ZEFR’s use of Subscriber content in performance of the Services or Subscriber’s breach of any of the provisions of this Agreement if: (a) ZEFR gives Subscriber prompt written notice of the Claim; (b) ZEFR grants Subscriber full and complete control over the defense and settlement of the Claim; (c) ZEFR provides assistance in connection with the defense and settlement of the Claim as Subscriber may reasonably request; and (d) ZEFR complies with any settlement or court order made in connection with the Claim. ZEFR shall not defend or settle any Claim without Subscriber’s prior written consent. ZEFR shall have the right to participate in the defense of the Claim at its own expense and with counsel of its own choosing, but Subscriber shall have sole control over the defense and settlement of the Claim.
+                            </li>
+                            <li>
+                                <u>Indemnification</u>. Subscriber shall indemnify ZEFR from and pay (a) all damages, costs, and attorneys’ fees finally awarded against ZEFR in any Claim pursuant to Section 11.1; (b) all out-of-pocket costs (including reasonable attorneys’ fees) reasonably incurred by ZEFR in connection with the defense of a Claim pursuant to Section 11.1 (other than attorneys’ fees and costs incurred without Subscriber’s consent after Subscriber has accepted defense of the Claim); and (c) all amounts that Subscriber agrees to pay to any third party to settle any Claim pursuant to Section 11.1.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>Limitations of liability</h3>
+                        <ol>
+                            <li>
+                                <u>Disclaimer of Indirect Damages</u>. <span class="text-uppercase">Notwithstanding anything to the contrary contained in this agreement, ZEFR will not, under any circumstances, be liable to subscriber for consequential, incidental, special, or exemplary damages arising out of or related to this agreement, including but not limited to lost profits or loss of business, even if ZEFR is apprised of the likelihood of such damages occurring.</span>
+                            </li>
+                            <li>
+                                <u>Cap on Liability</u>. <span class="text-uppercase">Under no circumstances will ZEFR’s total liability of all kinds arising out of or related to this agreement (including but not limited to warranty claims), regardless of the forum and regardless of whether any action or claim is based on contract, tort, or otherwise, exceed the total amount paid by subscriber to zefr pursuant to this agreement during the 6 months immediately preceding the date of the event giving rise to the claim.</span>
+                            </li>
+                            <li>
+                                <u>Independent Allocations of Risk</u>. <span class="text-uppercase">Each provision of this agreement that provides for a limitation of liability, disclaimer of warranties, or exclusion of damages is to allocate the risks of this agreement between the parties. this allocation is reflected in the pricing offered by ZEFR to subscriber and is an essential element of the basis of the bargain between the parties. Each of these provisions is severable and independent of all other provisions of this agreement. The limitations in this section 12 shall apply notwithstanding the failure of essential purpose of any limited remedy in this agreement.</span>
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        <h3>General</h3>
+                        <ol>
+                            <li>
+                                <u>Assignability</u>. Neither party may assign its rights, duties, or obligations pursuant to this Agreement without the other party’s prior written consent, which consent shall not be unreasonably withheld or delayed, except that ZEFR may assign this Agreement without Subscriber’s consent to a successor any successor to all or substantially all of the assets of ZEFR or the assets of ZEFR relating to the provision of the Services, including a successor by way of merger, acquisition, sale of assets, exclusive license, stock sale or operation of law.
+                            </li>
+                            <li>
+                                <u>Relationship</u>. ZEFR will be and act as an independent contractor (and not as the agent or representative of Subscriber) in the performance of this Agreement.
+                            </li>
+                            <li>
+                                <u>Subcontractors</u>. ZEFR may utilize subcontractors or other third party to perform its duties pursuant to this Agreement so long as ZEFR remains responsible for all of its obligations pursuant to this Agreement.
+                            </li>
+                            <li>
+                                <u>Notices</u>. Any notice required or permitted to be given in accordance with this Agreement shall be effective if it is in writing and sent by certified or registered mail, or insured courier, return receipt requested, to the appropriate party at the address set forth on the signature page hereto and with the appropriate postage affixed; provided that if notice is sent to ZEFR, a copy (which shall not constitute notice) shall also be sent to Kunzler Bean & Adamson, PC; Attn: James Platt, 50 West Broadway, Suite 1000 Salt Lake City, Utah 84101, with an additional copy to: ZEFR, Inc.: Attn: Legal, 4101 Redwood Ave., Los Angeles, CA 90066 and by fax at: 801.531.1929. Either party may change its address for receipt of notice by notice to the other party in accordance with this Section 13.4. Notices are deemed given two business days following the date of mailing or one business day following delivery to a courier.
+                            </li>
+                            <li>
+                                <u>Force Majeure</u>. Neither party shall be liable for, or be considered to be in breach of or default pursuant to this Agreement on account of, any delay or failure to perform as required by this Agreement as a result of any cause or condition beyond its reasonable control, so long as that party uses all commercially reasonable efforts to avoid or remove the causes of non-performance.
+                            </li>
+                            <li>
+                                <u>Governing Law</u>. This Agreement shall be interpreted, construed, and enforced in all respects in accordance with the local laws of the State of California, U.S.A., without reference to its choice of law rules and not including the provisions of the 1980 U.N. Convention on Contracts for the International Sale of Goods. Each party hereby irrevocably consents to the exclusive jurisdiction and venue of the federal, state, and local courts in Los Angeles County, California in connection with any action arising out of or in connection with this Agreement.
+                            </li>
+                            <li>
+                                <u>Waiver</u>. Any waiver of the provisions of this Agreement or of a party’s rights or remedies pursuant to this Agreement must be in writing to be effective. Failure, neglect, or delay by a party to enforce the provisions of this Agreement or its rights or remedies at any time, shall not be construed as a waiver of the party’s rights pursuant to this Agreement and shall not in any way affect the validity of the whole or any part of this Agreement or prejudice the party’s right to take subsequent action. Exercise or enforcement by either party of any right or remedy pursuant to this Agreement shall not preclude the enforcement by the party of any other right or remedy pursuant to this Agreement or that the party is entitled by law to enforce.
+                            </li>
+                            <li>
+                                <u>Severability</u>. If any part of this Agreement is found to be illegal, unenforceable, or invalid, the remaining portions of this Agreement shall remain in full force and effect. If any material limitation or restriction on the use of the Services pursuant to this Agreement is found to be illegal, unenforceable, or invalid, Subscriber’s right to use the Services shall immediately terminate.
+                            </li>
+                            <li>
+                                <u>Headings</u>. Headings are used in this Agreement for reference only and shall not be considered when interpreting this Agreement.
+                            </li>
+                            <li>
+                                <u>Counterparts</u>. This Agreement may be executed in any number of identical counterparts, notwithstanding that the parties have not signed the same counterpart, with the same effect as if the parties had signed the same document. All counterparts shall be construed as and constitute the same agreement. This Agreement may also be executed and delivered by facsimile or electronic transmission and such execution and delivery shall have the same force and effect of an original document with original signatures.
+                            </li>
+                            <li>
+                                <u>Entire Agreement</u>. This Agreement, including all exhibits and schedules, is the final and complete expression of the agreement between these parties regarding Subscriber’s use of the Services and Documentation and the performance of the Services. Any Order Form submitted by Subscriber and accepted by ZEFR after the date of this Agreement shall be incorporated into and be governed by this Agreement; for clarity, if any provision of an Order Form conflicts with this Agreement, the terms of this Agreement shall govern. This Agreement supersedes, and the terms of this Agreement govern, all previous oral and written communications or representations regarding these matters, all of which are merged into this Agreement. Notwithstanding the foregoing, this Agreement does not affect the validity of any agreements between the parties relating to professional services relating to the Services that ZEFR may provide. No employee, agent, or other representative of ZEFR has any authority to bind ZEFR with respect to any statement, representation, warranty, or other expression unless the same is specifically set forth in this Agreement. No usage of trade or other regular practice or method of dealing between the parties shall be used to modify, interpret, supplement, or alter the terms of this Agreement.
+                            </li>
+                            <li>
+                                <u>Modifications</u>. This Agreement may be updated or modified from time to time by ZEFR in its sole discretion. ZEFR shall provide Subscriber with at least 30 days’ prior notice of any such update or modification. Continued use of the Services following the effective date of any such update or modification shall constitute Subscriber’s acceptance of and agreement to such update or modification. ZEFR shall not be bound by, and specifically objects to, any term, condition, or other provision that is different from or in addition to this Agreement (whether or not it would materially alter this Agreement) that is proffered by Subscriber in any receipt, acceptance, confirmation, correspondence, or otherwise, unless ZEFR specifically agrees to such provision in writing and such writing is signed by an authorized agent of ZEFR.
+                            </li>
+                        </ol>
+                    </li>
+                <ol>
+                <p class="text-uppercase">
+                    Before placing a check in the [&quot;i accept and agree&quot;] box next to the [&quot;submit&quot;] button in connection with this agreement, subscriber is advised to carefully read the terms of this agreement and any applicable documentation.  by checking the [&quot;i accept and agree&quot;] box and clicking on the [&quot;submit&quot;] button, subscriber (1) agrees to be bound by and becomes a party to this agreement and (2) confirms that the individual entering this agreement has authority to so bind subscriber without further action by subscriber. If subscriber does not agree to the terms of this agreement, subscriber should not check the &quot;i accept and agree&quot; button nor click the &quot;submit&quot; button and the services will not be usable.
+                </p>
+            </article>
+        </main>
+    </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -64,6 +64,10 @@ h3 {
     color: #6d7884;
 }
 
+h3 span {
+    font-weight: normal;
+}
+
 p, li {
     line-height: 1.5em;
     color: #6d7884;
@@ -73,6 +77,10 @@ h4 {
     font-size: 18px;
     font-weight: bold;
     color: #6d7884;
+}
+
+em {
+    font-weight: bold;
 }
 
 .container {
@@ -85,4 +93,20 @@ h4 {
 
 .italic {
     font-style: italic;
+}
+
+.text-uppercase {
+    text-transform: uppercase;
+}
+
+.text-capitalize {
+    text-transform: capitalize;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.text-break {
+    word-break: break-word
 }

--- a/style.css
+++ b/style.css
@@ -64,7 +64,7 @@ h3 {
     color: #6d7884;
 }
 
-h3 span {
+h3 > span {
     font-weight: normal;
 }
 


### PR DESCRIPTION
### Summary
Adds the DV360 Terms of use page. We are basically re-using the existing styles, logos and sources from https://legal.zefr.com/terms.html

### How to Verify
1. Promote this PR to any DEV/Stage environment
2. Visit the page http://{ENV}/dv360/terms.html
3. The new DV360 terms of use page should appear:
![image](https://user-images.githubusercontent.com/45831273/64213198-e7a45680-ce60-11e9-8737-68f279ccfe74.png)


### Side Effects
New CSS classes were added to provide text formatting, which should not affect the existing CSS.

### Resolves

Fixes DBM-640

### Test Notes

### Code Reviewer(s)

;rfr @mark-kawakami-zefr @jdaccarett @kristentroll 
